### PR TITLE
Fix small typo in example assert test for locate_files

### DIFF
--- a/_lab/lab03.md
+++ b/_lab/lab03.md
@@ -172,7 +172,7 @@ Verify your understanding with this more involved example:
 ```
 # Example test
 files = {"lab00" : {"tests" : {"test.py" : None}, "lab00.py" : None, "README.md" : None}, "lab01" : {"params.txt" : None, "lab01.py" : None}, "base.py" : None }
-assert locate_files(files) == ["lab00/test/test.py", "lab00/lab00.py", "lab00/README.md", "lab01/params.txt", "lab01/lab01.py", "base.py"]
+assert locate_files(files) == ["lab00/tests/test.py", "lab00/lab00.py", "lab00/README.md", "lab01/params.txt", "lab01/lab01.py", "base.py"]
 # The files are labelled and put into a list for easy scanning
 ```
 


### PR DESCRIPTION
@ykharitonova  Small fix to a typo in the assert test for the locate_files function. Updated the path from 'test' to 'tests'. This change helps prevent confusion for students whose correct implementations may fail the example test due to the incorrect path.